### PR TITLE
Add script for BBBC021 metadata normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 .idea
 *.json
+
+# Other
+*.csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+click==6.7
+cycler==0.10.0
+decorator==4.1.2
+deep-profiler==0.0.0
+matplotlib==2.0.2
+networkx==1.11
+numpy==1.13.1
+olefile==0.44
+pandas==0.20.3
+Pillow==4.2.1
+pyparsing==2.2.0
+python-dateutil==2.6.1
+pytz==2017.2
+PyWavelets==0.5.2
+scikit-image==0.13.0
+scipy==0.19.1
+six==1.10.0

--- a/scripts/normalize_bbbc021_metadata.py
+++ b/scripts/normalize_bbbc021_metadata.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import pandas as pd
+import os.path
+import argparse
+import re
+
+parser = argparse.ArgumentParser(description='Convert BBBC021 metadata')
+parser.add_argument('input_path', help='The path to the BBBC021 metadata file')
+options = parser.parse_args()
+
+assert os.path.exists(options.input_path)
+
+bbbc021 = pd.read_csv(options.input_path)
+normalized = pd.DataFrame(columns=[
+    'Metadata_Plate', 'Metadata_Well', 'Metadata_Site', 'Plate_Map_Name',
+    'DNA', 'Tubulin', 'Actin', 'Replicate'
+])
+
+
+def join(path_series, filename_series):
+    return path_series + os.sep + filename_series
+
+
+normalized.Metadata_Plate = bbbc021.Image_Metadata_Plate_DAPI
+normalized.Metadata_Well = bbbc021.Image_Metadata_Well_DAPI
+normalized.DNA = join(bbbc021.Image_PathName_DAPI, bbbc021.Image_FileName_DAPI)
+normalized.Tubulin = join(bbbc021.Image_PathName_Tubulin,
+                          bbbc021.Image_FileName_Tubulin)
+normalized.Actin = join(bbbc021.Image_PathName_Actin,
+                        bbbc021.Image_FileName_Actin)
+normalized.Replicate = bbbc021.Replicate
+normalized.Metadata_Site = bbbc021.Image_FileName_DAPI.apply(
+    lambda name: re.search(r'_(s\d+)_', name).group(1))
+
+print(normalized.to_csv(sep=',', index=False))

--- a/scripts/normalize_bbbc021_metadata.py
+++ b/scripts/normalize_bbbc021_metadata.py
@@ -14,7 +14,7 @@ assert os.path.exists(options.input_path)
 bbbc021 = pd.read_csv(options.input_path)
 normalized = pd.DataFrame(columns=[
     'Metadata_Plate', 'Metadata_Well', 'Metadata_Site', 'Plate_Map_Name',
-    'DNA', 'Tubulin', 'Actin', 'Replicate'
+    'DNA', 'Tubulin', 'Actin', 'Replicate', 'Compound', 'Concentration'
 ])
 
 
@@ -32,5 +32,7 @@ normalized.Actin = join(bbbc021.Image_PathName_Actin,
 normalized.Replicate = bbbc021.Replicate
 normalized.Metadata_Site = bbbc021.Image_FileName_DAPI.apply(
     lambda name: re.search(r'_(s\d+)_', name).group(1))
+normalized.Compound = bbbc021.Image_Metadata_Compound
+normalized.Concentration = bbbc021.Image_Metadata_Concentration
 
 print(normalized.to_csv(sep=',', index=False))

--- a/scripts/normalize_bbbc021_metadata.py
+++ b/scripts/normalize_bbbc021_metadata.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-import pandas as pd
-import os.path
 import argparse
+import os.path
 import re
+
+import pandas as pd
 
 parser = argparse.ArgumentParser(description='Convert BBBC021 metadata')
 parser.add_argument('input_path', help='The path to the BBBC021 metadata file')

--- a/scripts/normalize_bbbc021_metadata.py
+++ b/scripts/normalize_bbbc021_metadata.py
@@ -14,7 +14,7 @@ assert os.path.exists(options.input_path)
 bbbc021 = pd.read_csv(options.input_path)
 normalized = pd.DataFrame(columns=[
     'Metadata_Plate', 'Metadata_Well', 'Metadata_Site', 'Plate_Map_Name',
-    'DNA', 'Tubulin', 'Actin', 'Replicate', 'Compound', 'Concentration'
+    'DNA', 'Tubulin', 'Actin', 'Replicate', 'Compound_Concentration'
 ])
 
 
@@ -24,15 +24,17 @@ def join(path_series, filename_series):
 
 normalized.Metadata_Plate = bbbc021.Image_Metadata_Plate_DAPI
 normalized.Metadata_Well = bbbc021.Image_Metadata_Well_DAPI
-normalized.DNA = join(bbbc021.Image_PathName_DAPI, bbbc021.Image_FileName_DAPI)
-normalized.Tubulin = join(bbbc021.Image_PathName_Tubulin,
+normalized.DNA = join(bbbc021.Image_Metadata_Plate_DAPI,
+                      bbbc021.Image_FileName_DAPI)
+normalized.Tubulin = join(bbbc021.Image_Metadata_Plate_DAPI,
                           bbbc021.Image_FileName_Tubulin)
-normalized.Actin = join(bbbc021.Image_PathName_Actin,
+normalized.Actin = join(bbbc021.Image_Metadata_Plate_DAPI,
                         bbbc021.Image_FileName_Actin)
 normalized.Replicate = bbbc021.Replicate
 normalized.Metadata_Site = bbbc021.Image_FileName_DAPI.apply(
     lambda name: re.search(r'_(s\d+)_', name).group(1))
-normalized.Compound = bbbc021.Image_Metadata_Compound
-normalized.Concentration = bbbc021.Image_Metadata_Concentration
+normalized.Compound_Concentration = (
+    bbbc021.Image_Metadata_Compound + '_' +
+    bbbc021.Image_Metadata_Concentration.apply(str))
 
 print(normalized.to_csv(sep=',', index=False))


### PR DESCRIPTION
Adds a package `scripts` with a script called `normalize_bbbc021_metadata`, that reads the official BBBC021 metadata file and transforms it into one that is understood by DeepProfiler.

Run with:

`python3 -m scripts.normalize_bbbc021_metadata BBBC021_v1_image.csv > metadata.csv`

fixes #14 